### PR TITLE
Use env vars for testing configuration

### DIFF
--- a/client/.env.dev
+++ b/client/.env.dev
@@ -1,0 +1,10 @@
+REACT_APP_COGNITO_ENDPOINT=https://cognito-idp.us-east-2.amazonaws.com/us-east-2_8sbfATJlO/.well-known/jwks.json
+REACT_APP_DYNAMO_API=http://localhost:3001/dxf-query?dxfNumber=
+REACT_APP_DXF_REGISTRATION_REDIRECT=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_DXF_REGISTRATION_SIGN_UP=http://localhost:3000/callback
+REACT_APP_LANDING_PAGE_REDIRECT=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_LANDING_PAGE_SIGN_IN=http://localhost:3000/callback
+REACT_APP_FETCH_MIRTH_DATA=http://127.0.0.1:3001/mirth-logs
+REACT_APP_FETCH_SMILE_DATA=http://127.0.0.1:3001/smile-query
+REACT_APP_FETCH_ENCOUNTER_DATA=http://127.0.0.1:3001/encounter-query
+REACT_APP_FETCH_PRACTITIONER_DATA=http://127.0.0.1:3001/practitioner-query

--- a/client/.env.prod
+++ b/client/.env.prod
@@ -1,0 +1,10 @@
+REACT_APP_COGNITO_ENDPOINT=https://cognito-idp.us-east-2.amazonaws.com/us-east-2_8sbfATJlO/.well-known/jwks.json
+REACT_APP_DYNAMO_API=https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber=
+REACT_APP_DXF_REGISTRATION_REDIRECT=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_DXF_REGISTRATION_SIGN_UP=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_LANDING_PAGE_REDIRECT=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_LANDING_PAGE_SIGN_IN=https://sbx.connectingforbetterhealth.com/callback
+REACT_APP_FETCH_MIRTH_DATA=https://sbx.connectingforbetterhealth.com/api/mirth-logs
+REACT_APP_FETCH_SMILE_DATA=https://sbx.connectingforbetterhealth.com/api/smile-query
+REACT_APP_FETCH_ENCOUNTER_DATA=https://sbx.connectingforbetterhealth.com/api/encounter-query
+REACT_APP_FETCH_PRACTITIONER_DATA=https://sbx.connectingforbetterhealth.com/api/practitioner-query

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -17,6 +17,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.dev
+.env.prod
 
 npm-debug.log*
 yarn-debug.log*

--- a/client/package.json
+++ b/client/package.json
@@ -32,8 +32,8 @@
   },
   "scripts": {
     "amp": "./build-scripts/MakeAmplifyFormsExportSubmitFunction.py",
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "dotenv -e .env.dev react-scripts start",
+    "build": "dotenv -e .env.prod react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/client/src/data/Callback.js
+++ b/client/src/data/Callback.js
@@ -14,7 +14,9 @@ const Callback = () => {
 
     if (code) {
       // Replace this URL with your backend endpoint
-      fetch('https://cognito-idp.us-east-2.amazonaws.com/us-east-2_8sbfATJlO/.well-known/jwks.json', {
+      // fetch('https://cognito-idp.us-east-2.amazonaws.com/us-east-2_8sbfATJlO/.well-known/jwks.json', {
+      const url = getEnvURL('COGNITO_ENDPOINT');
+      fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/data/Callback.js
+++ b/client/src/data/Callback.js
@@ -2,6 +2,8 @@
 import React, { useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { UserContext } from './Usercontext'; // Ensure correct path
+import { getEnvURL } from '../envUtils';
+
 
 const Callback = () => {
   const navigate = useNavigate();

--- a/client/src/data/Callback.js
+++ b/client/src/data/Callback.js
@@ -15,8 +15,6 @@ const Callback = () => {
     console.log('Authorization code:', code); // Debug: Log authorization code
 
     if (code) {
-      // Replace this URL with your backend endpoint
-      // fetch('https://cognito-idp.us-east-2.amazonaws.com/us-east-2_8sbfATJlO/.well-known/jwks.json', {
       const url = getEnvURL('COGNITO_ENDPOINT');
       fetch(url, {
         method: 'POST',

--- a/client/src/data/dsaFetch.js
+++ b/client/src/data/dsaFetch.js
@@ -6,10 +6,11 @@ import axios from 'axios';
 // prod is https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber=
 
 export const dynamoAPI = async (dxfNumber) => {
-  const url = 'https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber='+dxfNumber;
+  // const url = 'https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber='+dxfNumber;
+  const url = getEnvURL('DYNAMO_API')+dxfNumber;
   // console.log("this is the url:",url);
 try {
-  const response = await axios.get('https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber='+dxfNumber)
+  const response = await axios.get(url+dxfNumber)
   return response.data.data;
 } catch (error) {
   console.error('Error fetching data from DynamoDB:', error);

--- a/client/src/data/dsaFetch.js
+++ b/client/src/data/dsaFetch.js
@@ -3,11 +3,8 @@ import axios from 'axios';
 import { getEnvURL } from '../envUtils';
 
 // Function to fetch data from DynamoDB API
-// dev is http://localhost:3001/dxf-query?dxfNumber=
-// prod is https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber=
 
 export const dynamoAPI = async (dxfNumber) => {
-  // const url = 'https://sbx.connectingforbetterhealth.com/api/dxf-query?dxfNumber='+dxfNumber;
   const url = getEnvURL('DYNAMO_API')+dxfNumber;
   // console.log("this is the url:",url);
 try {

--- a/client/src/data/dsaFetch.js
+++ b/client/src/data/dsaFetch.js
@@ -1,5 +1,6 @@
 // dsaFetch.js
 import axios from 'axios';
+import { getEnvURL } from '../envUtils';
 
 // Function to fetch data from DynamoDB API
 // dev is http://localhost:3001/dxf-query?dxfNumber=

--- a/client/src/envUtils.js
+++ b/client/src/envUtils.js
@@ -1,0 +1,71 @@
+class EnvVarNotFoundError extends Error {
+    constructor(varName) {
+        super(`Environment variable ${varName} not found`);
+        this.name = 'EnvVarNotFoundError';
+    }
+}
+
+class UnknownEnvVarError extends Error {
+    constructor(varName) {
+        super(`Unknown environment variable ${varName} requested`);
+        this.name = 'UnknownEnvVarError';
+    }
+}
+
+const envVars = {};
+let config = {
+    throwError: true,
+    defaultValues: {
+        DYNAMO_API: "http://localhost:3001/dxf-query?dxfNumber=",
+        DXF_REGISTRATION_REDIRECT: "http://localhost:3000/callback",
+        LANDING_PAGE_REDIRECT: "http://localhost:3000/callback",
+        FETCH_MIRTH_DATA: "http://127.0.0.1:3001/mirth-logs",
+        FETCH_SMILE_DATA: "http://127.0.0.1:3001/smile-query",
+        FETCH_ENCOUNTER_DATA: "http://127.0.0.1:3001/encounter-query",
+        FETCH_PRACTITIONER_DATA: "http://127.0.0.1:3001/practitioner-query",
+        ORIGIN: "http://localhost:3000"
+    }
+};
+
+const requiredEnvVars = [
+    'COGNITO_ENDPOINT',
+    'DYNAMO_API',
+    'DXF_REGISTRATION_REDIRECT',
+    'DXF_REGISTRATION_SIGN_UP',
+    'LANDING_PAGE_REDIRECT',
+    'LANDING_PAGE_SIGN_IN',
+    'FETCH_MIRTH_DATA',
+    'FETCH_SMILE_DATA',
+    'FETCH_ENCOUNTER_DATA',
+    'FETCH_PRACTITIONER_DATA',
+    'ORIGIN'
+];
+
+// Automatically initialize environment variables when the module is loaded
+(function initializeEnvVars() {
+    requiredEnvVars.forEach(varName => {
+        const envVarName = `REACT_APP_${varName}`;
+        if (process.env[envVarName]) {
+            envVars[varName] = process.env[envVarName];
+        } else if (config.defaultValues[varName] !== undefined) {
+            envVars[varName] = config.defaultValues[varName];
+        } else if (config.throwError) {
+            throw new EnvVarNotFoundError(envVarName);
+        }
+    });
+})();
+
+// Function to get the URL from the cached environment variables
+function getEnvURL(envVarName) {
+    if (requiredEnvVars.includes(envVarName)) {
+        return envVars[envVarName];
+    } else {
+        throw new UnknownEnvVarError(envVarName);
+    }
+}
+
+module.exports = {
+    getEnvURL,
+    EnvVarNotFoundError,
+    UnknownEnvVarError
+};

--- a/client/src/pages/DxfRegistration.js
+++ b/client/src/pages/DxfRegistration.js
@@ -12,12 +12,9 @@ const DxfRegistration = () => {
  
 
   // Handler for the Sign Up button click, identical setup as sign in but could lead to a different path if needed
-  // Handler for the Sign In button click https://sbx.connectingforbetterhealth.com/callback, local = http://localhost:3000/callback
   const handleSignUp = () => {
     const clientId = '6ajbqdj9bvutetf9vrremr1clc';
-    // const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
     const redirectUri = getEnvURL('DXF_REGISTRATION_REDIRECT');
-    // const signUpUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/signup?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     const signInUri = `${getEnvURL('DXF_REGISTRATION_SIGN_UP')}?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     window.location.assign(signUpUri);
   };

--- a/client/src/pages/DxfRegistration.js
+++ b/client/src/pages/DxfRegistration.js
@@ -14,8 +14,10 @@ const DxfRegistration = () => {
   // Handler for the Sign In button click https://sbx.connectingforbetterhealth.com/callback, local = http://localhost:3000/callback
   const handleSignUp = () => {
     const clientId = '6ajbqdj9bvutetf9vrremr1clc';
-    const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
-    const signUpUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/signup?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
+    // const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
+    const redirectUri = getEnvURL('DXF_REGISTRATION_REDIRECT');
+    // const signUpUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/signup?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
+    const signInUri = `${getEnvURL('DXF_REGISTRATION_SIGN_UP')}?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     window.location.assign(signUpUri);
   };
 

--- a/client/src/pages/DxfRegistration.js
+++ b/client/src/pages/DxfRegistration.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import logoImage from './images/C4BHLogo.png';
+import { getEnvURL } from '../envUtils';
 
 const Logo = () => (
   <div className="logo">

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -23,8 +23,10 @@ const LandingPage = () => {
   const navigate = useNavigate();
   const handleSignIn = () => {
     const clientId = '6ajbqdj9bvutetf9vrremr1clc';
-    const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
-    const signInUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/login?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
+    // const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
+    const redirectUri = getEnvURL('LANDING_PAGE_REDIRECT');
+    // const signInUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/login?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
+    const signInUri = `${getEnvURL('LANDING_PAGE_SIGN_IN')}?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     window.location.assign(signInUri);
   };
 

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -20,13 +20,11 @@ const Logo = () => (
 );
 
 const LandingPage = () => {
-  // Handler for the Sign In button click https://sbx.connectingforbetterhealth.com/callback, local = http://localhost:3000/callback
+  // Handler for the Sign In button click
   const navigate = useNavigate();
   const handleSignIn = () => {
     const clientId = '6ajbqdj9bvutetf9vrremr1clc';
-    // const redirectUri = encodeURIComponent('https://sbx.connectingforbetterhealth.com/callback');
     const redirectUri = getEnvURL('LANDING_PAGE_REDIRECT');
-    // const signInUri = `https://sandbox-login.auth.us-east-2.amazoncognito.com/login?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     const signInUri = `${getEnvURL('LANDING_PAGE_SIGN_IN')}?client_id=${clientId}&response_type=code&scope=email+openid+phone&redirect_uri=${redirectUri}`;
     window.location.assign(signInUri);
   };

--- a/client/src/pages/LandingPage.js
+++ b/client/src/pages/LandingPage.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import logoImage from './images/C4BHLogo.png';
+import { getEnvURL } from '../envUtils';
 
 import { signIn } from 'aws-amplify/auth';
 

--- a/client/src/pages/Mirth.js
+++ b/client/src/pages/Mirth.js
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useTable } from 'react-table';
 import font from '../css/fonts.module.css'
 import flex from '../css/flex.module.css'
+import { getEnvURL } from '../envUtils';
 
 
 const Mirth = () => {

--- a/client/src/pages/Mirth.js
+++ b/client/src/pages/Mirth.js
@@ -45,9 +45,7 @@ const Mirth = () => {
   const data = useMemo(() => logs, [logs]);
   const tableInstance = useTable({ columns, data });
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = tableInstance;
-//dev URL: http://127.0.0.1:3001/mirth-logs, prod: https://sbx.connectingforbetterhealth.com/api/mirth-logs
 useEffect(() => {
-  // const apiEndpoint = 'https://sbx.connectingforbetterhealth.com/api/mirth-logs';
   const apiEndpoint = getEnvURL('FETCH_MIRTH_DATA');
   fetch(apiEndpoint)
     .then(response => {

--- a/client/src/pages/Mirth.js
+++ b/client/src/pages/Mirth.js
@@ -46,7 +46,8 @@ const Mirth = () => {
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = tableInstance;
 //dev URL: http://127.0.0.1:3001/mirth-logs, prod: https://sbx.connectingforbetterhealth.com/api/mirth-logs
 useEffect(() => {
-  const apiEndpoint = 'https://sbx.connectingforbetterhealth.com/api/mirth-logs';
+  // const apiEndpoint = 'https://sbx.connectingforbetterhealth.com/api/mirth-logs';
+  const apiEndpoint = getEnvURL('FETCH_MIRTH_DATA');
   fetch(apiEndpoint)
     .then(response => {
       if (!response.ok) {

--- a/client/src/pages/SmileCDR.js
+++ b/client/src/pages/SmileCDR.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTable } from 'react-table';
+import { getEnvURL } from '../envUtils';
 
 const SmileCDR = () => {
 

--- a/client/src/pages/SmileCDR.js
+++ b/client/src/pages/SmileCDR.js
@@ -122,7 +122,9 @@ const SmileCDR = () => {
       setError('');
 
       try {
-        const response = await fetch('https://sbx.connectingforbetterhealth.com/api/smile-query');
+        // const response = await fetch('https://sbx.connectingforbetterhealth.com/api/smile-query');
+        const url = getEnvURL('FETCH_SMILE_DATA');
+        const response = await fetch(url);
         if (!response.ok) {
           throw new Error(`HTTP status ${response.status}`);
         }
@@ -171,7 +173,9 @@ const SmileCDR = () => {
     //https://sbx.connectingforbetterhealth.com/api/encounter-query
     const fetchEncounterData = async () => {
       try {
-        const encounterResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/encounter-query');
+        // const encounterResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/encounter-query');
+        const url = getEnvURL('FETCH_ENCOUNTER_DATA');
+        const encounterResponse = await fetch(url);
         if (!encounterResponse.ok) {
           throw new Error(`HTTP status ${encounterResponse.status}`);
         }
@@ -242,7 +246,11 @@ const SmileCDR = () => {
     //https://sbx.connectingforbetterhealth.com/api/practitioner-query
     const fetchPractitionerData = async () => {
       try {
-        const practitionerResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/practitioner-query');
+        // const practitionerResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/practitioner-query');
+        const url = getEnvURL('FETCH_PRACTITIONER_DATA');
+        const practitionerResponse = await fetch(url);
+
+
         if (!practitionerResponse.ok) {
           throw new Error(`HTTP status ${practitionerResponse.status}`);
         }

--- a/client/src/pages/SmileCDR.js
+++ b/client/src/pages/SmileCDR.js
@@ -115,15 +115,13 @@ const SmileCDR = () => {
 
 //------------------------------------------------------fetch request to get all patient specific data from CDR
 
-  //http://127.0.0.1:3001/smile-query
-  //https://sbx.connectingforbetterhealth.com/api/smile-query
+
   useEffect(() => {
     const fetchData = async () => {
       setLoading(true);
       setError('');
 
       try {
-        // const response = await fetch('https://sbx.connectingforbetterhealth.com/api/smile-query');
         const url = getEnvURL('FETCH_SMILE_DATA');
         const response = await fetch(url);
         if (!response.ok) {
@@ -170,11 +168,8 @@ const SmileCDR = () => {
 
     //------------------------------------------------------fetch request to get all encounter data from CDR
 
-    //http://127.0.0.1:3001/encounter-query
-    //https://sbx.connectingforbetterhealth.com/api/encounter-query
     const fetchEncounterData = async () => {
       try {
-        // const encounterResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/encounter-query');
         const url = getEnvURL('FETCH_ENCOUNTER_DATA');
         const encounterResponse = await fetch(url);
         if (!encounterResponse.ok) {
@@ -243,11 +238,8 @@ const SmileCDR = () => {
 
 //------------------------------------------------------fetch request to get all practitioner data from CDR
 
-    //http://127.0.0.1:3001/practitioner-query
-    //https://sbx.connectingforbetterhealth.com/api/practitioner-query
     const fetchPractitionerData = async () => {
       try {
-        // const practitionerResponse = await fetch('https://sbx.connectingforbetterhealth.com/api/practitioner-query');
         const url = getEnvURL('FETCH_PRACTITIONER_DATA');
         const practitionerResponse = await fetch(url);
 

--- a/common/envUtils.js
+++ b/common/envUtils.js
@@ -1,0 +1,71 @@
+class EnvVarNotFoundError extends Error {
+    constructor(varName) {
+        super(`Environment variable ${varName} not found`);
+        this.name = 'EnvVarNotFoundError';
+    }
+}
+
+class UnknownEnvVarError extends Error {
+    constructor(varName) {
+        super(`Unknown environment variable ${varName} requested`);
+        this.name = 'UnknownEnvVarError';
+    }
+}
+
+const envVars = {};
+let config = {
+    throwError: true,
+    defaultValues: {
+        DYNAMO_API: "http://localhost:3001/dxf-query?dxfNumber=",
+        DXF_REGISTRATION_REDIRECT: "http://localhost:3000/callback",
+        LANDING_PAGE_REDIRECT: "http://localhost:3000/callback",
+        FETCH_MIRTH_DATA: "http://127.0.0.1:3001/mirth-logs",
+        FETCH_SMILE_DATA: "http://127.0.0.1:3001/smile-query",
+        ORIGIN: "http://localhost:3000"
+    }
+};
+
+const requiredEnvVars = [
+    'COGNITO_ENDPOINT',
+    'DYNAMO_API',
+    'DXF_REGISTRATION_REDIRECT',
+    'DXF_REGISTRATION_SIGN_UP',
+    'LANDING_PAGE_REDIRECT',
+    'LANDING_PAGE_SIGN_IN',
+    'FETCH_MIRTH_DATA',
+    'FETCH_SMILE_DATA',
+    'ENCOUNTER_CDR_API',
+    'MIRTH_API',
+    'PRACTITIONER_CDR_API',
+    'SMILE_API',
+    'ORIGIN'
+];
+
+// Automatically initialize environment variables when the module is loaded
+(function initializeEnvVars() {
+    requiredEnvVars.forEach(varName => {
+        const envVarName = `ENV_${varName}`;
+        if (process.env[envVarName]) {
+            envVars[varName] = process.env[envVarName];
+        } else if (config.defaultValues[varName] !== undefined) {
+            envVars[varName] = config.defaultValues[varName];
+        } else if (config.throwError) {
+            throw new EnvVarNotFoundError(envVarName);
+        }
+    });
+})();
+
+// Function to get the URL from the cached environment variables
+function getEnvURL(envVarName) {
+    if (requiredEnvVars.includes(envVarName)) {
+        return envVars[envVarName];
+    } else {
+        throw new UnknownEnvVarError(envVarName);
+    }
+}
+
+module.exports = {
+    getEnvURL,
+    EnvVarNotFoundError,
+    UnknownEnvVarError
+};

--- a/server/.env.dev
+++ b/server/.env.dev
@@ -1,0 +1,5 @@
+REACT_APP_ENCOUNTER_CDR_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter
+REACT_APP_MIRTH_API=https://52.7.12.154:8443/api/channels/f6d4fc04-babd-41b4-a087-9bfce4affce9/messages?status=TRANSFORMED&includeContent=true&limit=20
+REACT_APP_PRACTITIONER_CDR_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner
+REACT_APP_SMILE_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient
+REACT_APP_ORIGIN=http://localhost:3000

--- a/server/.env.prod
+++ b/server/.env.prod
@@ -1,0 +1,5 @@
+REACT_APP_ENCOUNTER_CDR_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter
+REACT_APP_MIRTH_API=https://52.7.12.154:8443/api/channels/f6d4fc04-babd-41b4-a087-9bfce4affce9/messages?status=TRANSFORMED&includeContent=true&limit=20
+REACT_APP_PRACTITIONER_CDR_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner
+REACT_APP_SMILE_API=http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient
+REACT_APP_ORIGIN=https://sbx.connectingforbetterhealth.com

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -21,3 +21,6 @@ amplifytools.xcconfig
 .secret-*
 **.sample
 #amplify-do-not-edit-end
+
+.env.dev
+.env.prod

--- a/server/api-EncounterCDR.js
+++ b/server/api-EncounterCDR.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
+import { getEnvURL } from './envUtils';
 
 // const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter';
 const apiEndpoint = getEnvURL('ENCOUNTER_CDR_API');

--- a/server/api-EncounterCDR.js
+++ b/server/api-EncounterCDR.js
@@ -3,7 +3,6 @@ import btoa from 'btoa';
 import https from 'https';
 import { getEnvURL } from './envUtils';
 
-// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter';
 const apiEndpoint = getEnvURL('ENCOUNTER_CDR_API');
 
 const queryEncounterCDR = async (req, res) => {

--- a/server/api-EncounterCDR.js
+++ b/server/api-EncounterCDR.js
@@ -2,7 +2,9 @@ import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
 
-const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter';
+// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Encounter';
+const apiEndpoint = getEnvURL('ENCOUNTER_CDR_API');
+
 const queryEncounterCDR = async (req, res) => {
   const username = 'admin';
   const password = 'password';

--- a/server/api-Mirth.js
+++ b/server/api-Mirth.js
@@ -4,7 +4,8 @@ import https from 'https';
 
 const getMirthLogs = async (req, res) => {
 
-  const apiEndpoint = 'https://52.7.12.154:8443/api/channels/f6d4fc04-babd-41b4-a087-9bfce4affce9/messages?status=TRANSFORMED&includeContent=true&limit=20';
+  // const apiEndpoint = 'https://52.7.12.154:8443/api/channels/f6d4fc04-babd-41b4-a087-9bfce4affce9/messages?status=TRANSFORMED&includeContent=true&limit=20';
+  const apiEndpoint = getEnvURL('MIRTH_API');
   const username = 'admin';
   const password = 'C4BH126!';
   const encodedCredentials = btoa(`${username}:${password}`);

--- a/server/api-Mirth.js
+++ b/server/api-Mirth.js
@@ -5,7 +5,6 @@ import { getEnvURL } from './envUtils';
 
 const getMirthLogs = async (req, res) => {
 
-  // const apiEndpoint = 'https://52.7.12.154:8443/api/channels/f6d4fc04-babd-41b4-a087-9bfce4affce9/messages?status=TRANSFORMED&includeContent=true&limit=20';
   const apiEndpoint = getEnvURL('MIRTH_API');
   const username = 'admin';
   const password = 'C4BH126!';

--- a/server/api-Mirth.js
+++ b/server/api-Mirth.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
+import { getEnvURL } from './envUtils';
 
 const getMirthLogs = async (req, res) => {
 

--- a/server/api-PractitionerCDR.js
+++ b/server/api-PractitionerCDR.js
@@ -2,7 +2,9 @@ import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
 
-const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner';
+// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner';
+const apiEndpoint = getEnvURL('PRACTITIONER_CDR_API');
+
 const queryPractitionerCDR = async (req, res) => {
   const username = 'admin';
   const password = 'password';

--- a/server/api-PractitionerCDR.js
+++ b/server/api-PractitionerCDR.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
+import { getEnvURL } from './envUtils';
 
 // const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner';
 const apiEndpoint = getEnvURL('PRACTITIONER_CDR_API');

--- a/server/api-PractitionerCDR.js
+++ b/server/api-PractitionerCDR.js
@@ -3,7 +3,6 @@ import btoa from 'btoa';
 import https from 'https';
 import { getEnvURL } from './envUtils';
 
-// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Practitioner';
 const apiEndpoint = getEnvURL('PRACTITIONER_CDR_API');
 
 const queryPractitionerCDR = async (req, res) => {

--- a/server/api-Smile.js
+++ b/server/api-Smile.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
+import { getEnvURL } from './envUtils';
 
 // const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient';
 const apiEndpoint = getEnvURL('SMILE_API');

--- a/server/api-Smile.js
+++ b/server/api-Smile.js
@@ -3,7 +3,6 @@ import btoa from 'btoa';
 import https from 'https';
 import { getEnvURL } from './envUtils';
 
-// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient';
 const apiEndpoint = getEnvURL('SMILE_API');
 
 const querySmile = async (req, res) => {

--- a/server/api-Smile.js
+++ b/server/api-Smile.js
@@ -2,7 +2,9 @@ import fetch from 'node-fetch';
 import btoa from 'btoa';
 import https from 'https';
 
-const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient';
+// const apiEndpoint = 'http://ec2-18-188-102-170.us-east-2.compute.amazonaws.com:8000/Patient';
+const apiEndpoint = getEnvURL('SMILE_API');
+
 const querySmile = async (req, res) => {
   const username = 'admin';
   const password = 'password';

--- a/server/envUtils.js
+++ b/server/envUtils.js
@@ -16,24 +16,11 @@ const envVars = {};
 let config = {
     throwError: true,
     defaultValues: {
-        DYNAMO_API: "http://localhost:3001/dxf-query?dxfNumber=",
-        DXF_REGISTRATION_REDIRECT: "http://localhost:3000/callback",
-        LANDING_PAGE_REDIRECT: "http://localhost:3000/callback",
-        FETCH_MIRTH_DATA: "http://127.0.0.1:3001/mirth-logs",
-        FETCH_SMILE_DATA: "http://127.0.0.1:3001/smile-query",
         ORIGIN: "http://localhost:3000"
     }
 };
 
 const requiredEnvVars = [
-    'COGNITO_ENDPOINT',
-    'DYNAMO_API',
-    'DXF_REGISTRATION_REDIRECT',
-    'DXF_REGISTRATION_SIGN_UP',
-    'LANDING_PAGE_REDIRECT',
-    'LANDING_PAGE_SIGN_IN',
-    'FETCH_MIRTH_DATA',
-    'FETCH_SMILE_DATA',
     'ENCOUNTER_CDR_API',
     'MIRTH_API',
     'PRACTITIONER_CDR_API',
@@ -44,7 +31,7 @@ const requiredEnvVars = [
 // Automatically initialize environment variables when the module is loaded
 (function initializeEnvVars() {
     requiredEnvVars.forEach(varName => {
-        const envVarName = `ENV_${varName}`;
+        const envVarName = `REACT_APP_${varName}`;
         if (process.env[envVarName]) {
             envVars[varName] = process.env[envVarName];
         } else if (config.defaultValues[varName] !== undefined) {

--- a/server/main.js
+++ b/server/main.js
@@ -11,9 +11,7 @@ import { getEnvURL } from './envUtils';
 const app = express();
 const PORT = process.env.PORT || 3001;
 
-//dev is "http://localhost:3000", Prod is "https://sbx.connectingforbetterhealth.com" for origin
 app.use(cors({
-    // origin: 'https://sbx.connectingforbetterhealth.com'
     origin: getEnvURL('ORIGIN')
 
   }));

--- a/server/main.js
+++ b/server/main.js
@@ -5,6 +5,7 @@ import getMirthLogs from './api-Mirth.js';
 import queryEncounterCDR from './api-EncounterCDR.js';
 import queryPractitionerCDR from './api-PractitionerCDR.js';
 import queryDynamoDB from './api-DynamoDB.js';
+import { getEnvURL } from './envUtils';
 
 
 const app = express();

--- a/server/main.js
+++ b/server/main.js
@@ -12,7 +12,9 @@ const PORT = process.env.PORT || 3001;
 
 //dev is "http://localhost:3000", Prod is "https://sbx.connectingforbetterhealth.com" for origin
 app.use(cors({
-    origin: 'https://sbx.connectingforbetterhealth.com'
+    // origin: 'https://sbx.connectingforbetterhealth.com'
+    origin: getEnvURL('ORIGIN')
+
   }));
 
 app.get('/mirth-logs', getMirthLogs);

--- a/server/package.json
+++ b/server/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
+    "start": "dotenv -e .env.dev react-scripts start",
+    "build": "dotenv -e .env.prod react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
 Use npm to load environment variables depending on if it's run in production (built as release) or in test (npm run start)
 Store the urls that go into CORs headers, and the URLs for the APIs (like in dsaFetch) in environment variables

Added configurable environment variables for urls with defaults for dev environment.
Added import statements and split envutil into 2 files for client and server. 
Modified package.json files to grab env variables from .env files.
Added gitignore lines so that sensitive env variables dont end up in the repo.
Removed unneeded comments